### PR TITLE
Add pylonboard to official url sources

### DIFF
--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -22,6 +22,7 @@ function validateHostname() {
     Pylon: ["pylon.money"],
     Astroport: ["astroport.fi"],
     Terraswap: ["terraswap.io"],
+    PylonBoard: ["pylonboard.money"],
   }
 
   const hostname = document.location.hostname


### PR DESCRIPTION
This PR will:

- Add pylonboard.money to the official source list 


### notes

PylonBoard is a community driven dashboard and feature-addon for Pylon protocol.
All our src is OS over here:
https://github.com/pylonboard

