### PR TITLE
feat: switch wallets localterra

### DIFF
--- a/src/extension/auth/SwitchWalletButton.tsx
+++ b/src/extension/auth/SwitchWalletButton.tsx
@@ -5,13 +5,16 @@ import { ModalButton } from "components/feedback"
 import { useAuth } from "auth"
 import SwitchWallet from "./SwitchWallet"
 import styles from "./ConnectedWallet.module.scss"
+import { useNetworkState } from "../../data/wallet"
 
 const SwitchWalletButton = () => {
   const { t } = useTranslation()
   const address = useAddress()
   const { wallets } = useAuth()
+  const [network] = useNetworkState()
 
-  return wallets.length < 2 ? null : (
+  return (wallets.length < 2 && network !== "localterra") ||
+    wallets.length === 0 ? null : (
     <ModalButton
       title={t("Switch wallet")}
       renderButton={(open) => (


### PR DESCRIPTION
LocalTerra offers Preconfigured wallets `test1-10`.  This change will allow the `Switch wallet` button to show when the user has selected LocalTerra and has at least one wallet.

Currently, the `Switch wallet` button will only show if the user has more than 1 wallet available, however, we want a user with only 1 wallet to be able to change to a preconfigured testing wallet on LocalTerra.


Uploading switch_wallets_localterra.mov…