### PR TITLE
fix: switch overflow-y to scroll

### DIFF
--- a/src/extension/components/ExtensionPage.module.scss
+++ b/src/extension/components/ExtensionPage.module.scss
@@ -1,5 +1,6 @@
 .page {
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: scroll;
   background-color: var(--card-bg-muted);
   height: calc(100% - var(--header-height));
   // padding here to position progress bar


### PR DESCRIPTION
issue: extension page height added in 7.1.6 was causing vertical scroll to lock.

- [x] switch overflow hidden to scroll on y axis, hidden on x axis