### PR TITLE
support msg grant authorization whitelist

### DIFF
--- a/src/data/Terra/TerraAssets.ts
+++ b/src/data/Terra/TerraAssets.ts
@@ -47,6 +47,13 @@ export const useCW20Contracts = () => {
   return useTerraAssetsByNetwork<CW20Contracts>("cw20/contracts.json")
 }
 
+export const useMsgGrantAuthorization = (disabled = false) => {
+  return useTerraAssetsByNetwork<MsgGrantAuthorizations>(
+    "msgs/MsgGrantAuthorization.json",
+    disabled
+  )
+}
+
 export const useCW20Whitelist = (disabled = false) => {
   return useTerraAssetsByNetwork<CW20Whitelist>(
     "cw20/tokens.json",

--- a/src/extension/modules/ConfirmTx.tsx
+++ b/src/extension/modules/ConfirmTx.tsx
@@ -12,7 +12,7 @@ import useToPostMultisigTx from "pages/multisig/utils/useToPostMultisigTx"
 import { isWallet, useAuth } from "auth"
 import { PasswordError } from "auth/scripts/keystore"
 import { getOpenURL, getStoredPassword } from "../storage"
-import { getIsDangerousTx, SignBytesRequest, TxRequest } from "../utils"
+import { useIsDangerousTx, SignBytesRequest, TxRequest } from "../utils"
 import { useRequest } from "../RequestContainer"
 import ExtensionPage from "../components/ExtensionPage"
 import ConfirmButtons from "../components/ConfirmButtons"
@@ -53,12 +53,13 @@ const ConfirmTx = (props: TxRequest | SignBytesRequest) => {
   const [incorrect, setIncorrect] = useState<string>()
   const [submitting, setSubmitting] = useState(false)
 
-  const disabled =
-    "tx" in props && getIsDangerousTx(props.tx)
-      ? t("Dangerous tx")
-      : passwordRequired && !password
-      ? t("Enter password")
-      : ""
+  let isDangerousTx = useIsDangerousTx("tx" in props ? props.tx.msgs : [])
+
+  const disabled = isDangerousTx
+    ? t("Dangerous tx")
+    : passwordRequired && !password
+    ? t("Enter password")
+    : ""
 
   const navigate = useNavigate()
   const toPostMultisigTx = useToPostMultisigTx()

--- a/src/types/token.d.ts
+++ b/src/types/token.d.ts
@@ -95,6 +95,14 @@ interface NativeTokenItem {
   token: CoinDenom
 }
 
+/* msgs: MsgGrantAuthorization */
+type MsgGrantAuthorizations = Record<TerraAddress, MsgGrantAuthorizationItem>
+interface MsgGrantAuthorizationItem {
+  url: string
+  types: string[]
+  msgs: string[]
+}
+
 /* cw20: pair */
 type CW20Pairs = Record<TerraAddress, PairDetails>
 type Dex = "terraswap" | "astroport"


### PR DESCRIPTION
This PR adds the MsgGrantAuthorization whitelist to station extension.

This needs to be reviewed in combination with https://github.com/terra-money/assets/pull/753

First merge https://github.com/terra-money/assets/pull/753


I do not know how to test it, so I was not able to run it.