### PR TITLE
fix: allow wallet sbumission on confirm password entered first

### DIFF
--- a/src/auth/modules/create/CreateWalletForm.tsx
+++ b/src/auth/modules/create/CreateWalletForm.tsx
@@ -45,6 +45,7 @@ const CreateWalletForm = () => {
       <FormItem label={t("Password")} error={errors.password?.message}>
         <Input
           {...register("password", { validate: validate.password })}
+          onChange={() => form.trigger("confirm")}
           type="password"
         />
       </FormItem>


### PR DESCRIPTION
allow form submission if confirm is entered before password field (edge case)
note that error text will still display