### PR TITLE
fix: Display Buy button only when mainnet is selected

### DIFF
--- a/public/firefox.manifest.json
+++ b/public/firefox.manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Station Wallet",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "background": {
     "scripts": ["background.js"],
     "persistent": true

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Station Wallet",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "background": {
     "service_worker": "background.js",
     "type": "module"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Station Wallet",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "background": {
     "service_worker": "background.js",
     "type": "module"

--- a/src/components/token/Read.tsx
+++ b/src/components/token/Read.tsx
@@ -100,10 +100,10 @@ export const ReadPercent = forwardRef(
 
     return (
       <span className={styles.component} ref={ref}>
-        {integer.replace(/\B(?=(\d{3})+(?!\d))/g, "'")}
+        {(integer ?? "0").replace(/\B(?=(\d{3})+(?!\d))/g, "'")}
         {decimal && (
           <>
-            <span className={cx({ small: Number(integer) })}>
+            <span className={cx({ small: Number(integer ?? "0") })}>
               {decimal && `.${decimal}`}
             </span>
             <span className={styles.small}>%</span>

--- a/src/extension/components/OriginCard.tsx
+++ b/src/extension/components/OriginCard.tsx
@@ -12,10 +12,12 @@ interface ManifestResult {
 }
 
 async function getIconAndTitle(hostname: string): Promise<ManifestResult> {
+  const baseUrl =
+    hostname.startsWith("https://") || hostname.startsWith("http://")
+      ? hostname
+      : `https://${hostname}`
   try {
-    const { data: manifest } = await axios.get(
-      `https://${hostname}/manifest.json`
-    )
+    const { data: manifest } = await axios.get(`${baseUrl}/manifest.json`)
 
     const title = manifest.name ?? manifest.short_name
     let faviconUrl
@@ -26,9 +28,12 @@ async function getIconAndTitle(hostname: string): Promise<ManifestResult> {
       faviconUrl = icon.src
 
       // If the URL is relative, make it absolute
-      if (!faviconUrl.startsWith("http")) {
-        const baseUrl = new URL(`https://${hostname}`)
-        faviconUrl = new URL(faviconUrl, baseUrl).href
+      if (
+        !faviconUrl.startsWith("https://") &&
+        !faviconUrl.startsWith("http://")
+      ) {
+        const url = new URL(baseUrl)
+        faviconUrl = new URL(faviconUrl, url).href
       }
     }
 

--- a/src/extension/modules/TxDetails.tsx
+++ b/src/extension/modules/TxDetails.tsx
@@ -16,7 +16,7 @@ const TxDetails = ({ origin, timestamp, tx }: TxRequest) => {
 
   const fees = fee?.amount.toData()
   const contents = [
-    { title: t("Network"), content: `${network[chainID]?.name} (${chainID})` },
+    { title: t("Network"), content: `${network[chainID].name} (${chainID})` },
     { title: t("Origin"), content: origin },
     { title: t("Timestamp"), content: <ToNow update>{timestamp}</ToNow> },
     { title: t("Fee"), content: fees && <ReadMultiple list={fees} /> },

--- a/src/extension/modules/TxDetails.tsx
+++ b/src/extension/modules/TxDetails.tsx
@@ -16,7 +16,7 @@ const TxDetails = ({ origin, timestamp, tx }: TxRequest) => {
 
   const fees = fee?.amount.toData()
   const contents = [
-    { title: t("Network"), content: `${network[chainID].name} (${chainID})` },
+    { title: t("Network"), content: `${network[chainID]?.name} (${chainID})` },
     { title: t("Origin"), content: origin },
     { title: t("Timestamp"), content: <ToNow update>{timestamp}</ToNow> },
     { title: t("Fee"), content: fees && <ReadMultiple list={fees} /> },

--- a/src/pages/wallet/AssetPage.module.scss
+++ b/src/pages/wallet/AssetPage.module.scss
@@ -49,6 +49,7 @@
   @include flex(space-between);
   background-color: var(--card-bg);
   padding-top: 0.6rem;
+  padding: 20px 20px;
   gap: 0.6rem;
   width: 100%;
 

--- a/src/pages/wallet/NetWorth.tsx
+++ b/src/pages/wallet/NetWorth.tsx
@@ -16,6 +16,7 @@ import classNames from "classnames"
 import qs from "qs"
 import { useNetwork } from "data/wallet"
 import { useInterchainAddresses } from "auth/hooks/useAddress"
+import { useNetworkName } from "data/wallet"
 
 const cx = classNames.bind(styles)
 
@@ -28,6 +29,7 @@ const NetWorth = () => {
   const { setRoute, route } = useWalletRoute()
   const addresses = useInterchainAddresses()
   const network = useNetwork()
+  const networkName = useNetworkName()
 
   // TODO: show CW20 balances and staked tokens
   const coinsValue = coins?.reduce((acc, { amount, denom }) => {
@@ -103,12 +105,14 @@ const NetWorth = () => {
           </Button>
           <h3>{capitalize(t("receive"))}</h3>
         </div>
-        <div className={styles.button__wrapper}>
-          <Button onClick={openKadoWindow}>
-            <AddIcon className={styles.icon} />
-          </Button>
-          <h2>{t(capitalize("buy"))}</h2>
-        </div>
+        {networkName === "mainnet" && (
+          <div className={styles.button__wrapper}>
+            <Button onClick={openKadoWindow}>
+              <AddIcon className={styles.icon} />
+            </Button>
+            <h2>{t(capitalize("buy"))}</h2>
+          </div>
+        )}
       </div>
     </article>
   )

--- a/src/pages/wallet/SendPage.tsx
+++ b/src/pages/wallet/SendPage.tsx
@@ -321,7 +321,7 @@ const SendPage = () => {
     gasAdjustment:
       getChainIDFromAddress(addresses?.[chain ?? ""], networks) !== chain &&
       AccAddress.validate(token?.denom ?? "")
-        ? 1.5
+        ? 2
         : 1,
   }
 


### PR DESCRIPTION
All buy operations can only be done on mainnet, therefore, Station should only display the `Buy` button if the network is mainnet.