### PR TITLE
Update information exposed by the extension

### DIFF
--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -76,8 +76,8 @@ function setupEvents() {
     if (namespace === "local") {
       if (
         changes.wallet &&
-        (Object.values(changes.wallet.oldValue.addresses).join(",") !==
-          Object.values(changes.wallet.newValue.addresses).join(",") ||
+        (changes.wallet.oldValue.address !== changes.wallet.newValue.address ||
+          changes.wallet.oldValue.name !== changes.wallet.newValue.name ||
           Object.values(changes.wallet.oldValue.pubkey).join(",") !==
             Object.values(changes.wallet.newValue.pubkey).join(","))
       ) {
@@ -87,9 +87,8 @@ function setupEvents() {
         window.dispatchEvent(event)
       }
       if (
-        changes.networks &&
-        Object.keys(changes.networks.oldValue).join(",") !==
-          Object.keys(changes.networks.newValue).join(",")
+        changes.networkName &&
+        changes.networkName.oldValue !== changes.networkName.newValue
       ) {
         const event = new CustomEvent("station_network_change", {
           detail: changes.networks.newValue,
@@ -100,7 +99,9 @@ function setupEvents() {
   }
 
   extension.storage.local.get(["connect"], ({ connect }) => {
-    const isAllowed = ((connect && connect.allowed) || []).includes(window.location.origin)
+    const isAllowed = ((connect && connect.allowed) || []).includes(
+      window.location.origin
+    )
 
     if (isAllowed) {
       extension.storage.onChanged.addListener(createEvent)

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -87,6 +87,15 @@ function setupEvents() {
         window.dispatchEvent(event)
       }
       if (
+        changes.wallet &&
+        changes.wallet.oldValue.theme !== changes.wallet.newValue.theme
+      ) {
+        const event = new CustomEvent("station_theme_change", {
+          detail: changes.wallet.newValue.theme,
+        })
+        window.dispatchEvent(event)
+      }
+      if (
         changes.networkName &&
         changes.networkName.oldValue !== changes.networkName.newValue
       ) {

--- a/src/auth/hooks/useAddress.ts
+++ b/src/auth/hooks/useAddress.ts
@@ -2,7 +2,7 @@ import { useConnectedWallet } from "@terra-money/use-wallet"
 import { useNetworks } from "app/InitNetworks"
 import { addressFromWords } from "utils/bech32"
 import useAuth from "./useAuth"
-import { useChainID } from "./useNetwork"
+import { useChainID, useNetworkName } from "./useNetwork"
 import { useNetwork } from "data/wallet"
 
 /* auth | walle-provider */
@@ -17,9 +17,26 @@ const useAddress = () => {
     ? addressFromWords(wallet.words["330"])
     : undefined
 }
+
 export const useAllInterchainAddresses = () => {
   const connected = useConnectedWallet()
+  const { wallet } = useAuth()
+  const { networks } = useNetworks()
+  const networkName = useNetworkName()
+
   if (connected?.addresses) return connected.addresses
+
+  const words = wallet?.words
+  if (!words) return
+
+  const addresses = Object.values(networks[networkName]).reduce(
+    (acc, { prefix, coinType, chainID }) => {
+      acc[chainID] = addressFromWords(words[coinType] as string, prefix)
+      return acc
+    },
+    {} as Record<string, string>
+  )
+  return addresses
 }
 
 export const useInterchainAddresses = () => {

--- a/src/auth/scripts/decrypt.ts
+++ b/src/auth/scripts/decrypt.ts
@@ -4,25 +4,23 @@ const keySize = 256
 const iterations = 100
 
 const decrypt = (transitmessage: string, pass: string) => {
-  try {
-    const salt = CryptoJS.enc.Hex.parse(transitmessage.substr(0, 32))
-    const iv = CryptoJS.enc.Hex.parse(transitmessage.substr(32, 32))
-    const encrypted = transitmessage.substring(64)
+  const salt = CryptoJS.enc.Hex.parse(transitmessage.substr(0, 32))
+  const iv = CryptoJS.enc.Hex.parse(transitmessage.substr(32, 32))
+  const encrypted = transitmessage.substring(64)
 
-    const key = CryptoJS.PBKDF2(pass, salt, {
-      keySize: keySize / 32,
-      iterations: iterations,
-    })
+  const key = CryptoJS.PBKDF2(pass, salt, {
+    keySize: keySize / 32,
+    iterations: iterations,
+  })
 
-    const decrypted = CryptoJS.AES.decrypt(encrypted, key, {
-      iv: iv,
-      padding: CryptoJS.pad.Pkcs7,
-      mode: CryptoJS.mode.CBC,
-    }).toString(CryptoJS.enc.Utf8)
-    return decrypted
-  } catch (error) {
-    return ""
-  }
+  const decrypted = CryptoJS.AES.decrypt(encrypted, key, {
+    iv: iv,
+    padding: CryptoJS.pad.Pkcs7,
+    mode: CryptoJS.mode.CBC,
+  }).toString(CryptoJS.enc.Utf8)
+
+  if (!decrypted) throw new Error("Incorrect password")
+  return decrypted
 }
 
 export default decrypt

--- a/src/extension/App.tsx
+++ b/src/extension/App.tsx
@@ -17,29 +17,36 @@ import Auth from "./auth/Auth"
 import Header from "./layouts/Header"
 import Front from "./modules/Front"
 import ManageWallets from "./auth/SelectWallets"
-import { useInterchainAddresses, usePubkey } from "auth/hooks/useAddress"
+import { useAllInterchainAddresses, usePubkey } from "auth/hooks/useAddress"
 import { Flex } from "components/layout"
 import NetworkStatus from "components/display/NetworkStatus"
 import Preferences from "app/sections/Preferences"
 import { useAuth } from "auth"
 import is from "auth/scripts/is"
+import { useNetworks } from "app/InitNetworks"
 
 const App = () => {
-  const network = useNetwork()
+  const { networks } = useNetworks()
   const name = useNetworkName()
   const chainID = useChainID()
   const address = useAddress()
   const pubkey = usePubkey()
-  const addresses = useInterchainAddresses()
+  const addresses = useAllInterchainAddresses()
   const { wallet } = useAuth()
 
   useEffect(() => {
-    storeNetwork({ ...network[chainID], name }, network)
-  }, [network, chainID, name])
+    storeNetwork({ ...networks[name][chainID], name }, networks[name])
+  }, [networks, chainID, name])
 
   useEffect(() => {
     if (address)
-      storeWalletAddress(address, addresses ?? {}, is.ledger(wallet), pubkey)
+      storeWalletAddress(
+        address,
+        addresses ?? {},
+        wallet?.name,
+        is.ledger(wallet),
+        pubkey
+      )
     else clearWalletAddress()
   }, [address, addresses, pubkey, wallet])
 

--- a/src/extension/App.tsx
+++ b/src/extension/App.tsx
@@ -24,6 +24,7 @@ import Preferences from "app/sections/Preferences"
 import { useAuth } from "auth"
 import is from "auth/scripts/is"
 import { useNetworks } from "app/InitNetworks"
+import { useTheme } from "data/settings/Theme"
 
 const App = () => {
   const { networks } = useNetworks()
@@ -32,6 +33,7 @@ const App = () => {
   const address = useAddress()
   const pubkey = usePubkey()
   const addresses = useAllInterchainAddresses()
+  const { name: theme } = useTheme()
   const { wallet } = useAuth()
 
   useEffect(() => {
@@ -40,13 +42,15 @@ const App = () => {
 
   useEffect(() => {
     if (address)
-      storeWalletAddress(
+      storeWalletAddress({
         address,
-        addresses ?? {},
-        wallet?.name,
-        is.ledger(wallet),
-        pubkey
-      )
+        addresses: addresses ?? {},
+        name: wallet?.name,
+        ledger: is.ledger(wallet),
+        pubkey,
+        network: name,
+        theme,
+      })
     else clearWalletAddress()
   }, [address, addresses, pubkey, wallet])
 

--- a/src/extension/storage.ts
+++ b/src/extension/storage.ts
@@ -11,15 +11,17 @@ export const storeNetwork = (
 }
 
 /* wallet */
-export const storeWalletAddress = (
-  address: AccAddress,
-  addresses: Record<ChainID, AccAddress>,
-  name?: string,
-  ledger?: boolean,
+export const storeWalletAddress = (wallet: {
+  address: AccAddress
+  addresses: Record<ChainID, AccAddress>
+  name?: string
+  ledger?: boolean
   pubkey?: { "330": string; "118"?: string }
-) => {
+  network: string
+  theme: string
+}) => {
   extension.storage?.local.set({
-    wallet: { address, addresses, ledger, pubkey, name },
+    wallet,
   })
 }
 

--- a/src/extension/storage.ts
+++ b/src/extension/storage.ts
@@ -7,18 +7,19 @@ export const storeNetwork = (
   network: TerraNetwork,
   networks: Record<ChainID, InterchainNetwork>
 ) => {
-  extension.storage?.local.set({ network, networks })
+  extension.storage?.local.set({ network, networks, networkName: network.name })
 }
 
 /* wallet */
 export const storeWalletAddress = (
   address: AccAddress,
   addresses: Record<ChainID, AccAddress>,
+  name?: string,
   ledger?: boolean,
   pubkey?: { "330": string; "118"?: string }
 ) => {
   extension.storage?.local.set({
-    wallet: { address, addresses, ledger, pubkey },
+    wallet: { address, addresses, ledger, pubkey, name },
   })
 }
 


### PR DESCRIPTION
The extension now exposes the following information after a connection to a webapp:
- The wallet name set by the user inside the extension
- The theme selected in the extension (light, dark, blossom, moon, ...)
- The name of the network selected in the extension (mainnet, testnet, classic, localterra)
- All networks including the disabled ones, it's now up to the webapp to do the validation

Updates on the events emitted by the extension:
- `station_wallet_change` and `station_network_change` are now triggered only when the network or the wallet is actually changed and not every time a network is validated
- there is a new event `station_theme_change` which is triggered every time the user changes the theme inside the extension
