### PR TITLE
feat: display gamm tokens properly

### DIFF
--- a/src/data/external/osmosis.ts
+++ b/src/data/external/osmosis.ts
@@ -1,0 +1,71 @@
+import { useQuery } from "react-query"
+import request from "axios"
+import { queryKey } from "../query"
+
+// https://api-osmosis.imperator.co/swagger/
+export const OSMOSIS_API_URL = "https://api-osmosis.imperator.co"
+
+export const GAMM_TOKEN_DECIMALS = 18
+export const OSMO_ICON =
+  "https://station-assets.terra.money/img/chains/Osmosis.svg"
+
+interface IOsmosisPoolAsset {
+  symbol: string
+  amount: number
+  denom: string
+  coingecko_id: string
+  liquidity: number
+  liquidity_24h_change: number
+  volume_24h: number
+  volume_24h_change: number
+  volume_7d: number
+  price: number
+  fees: string
+}
+
+interface IOsmosisPoolResponse {
+  // pool_id: pool asset array
+  [key: string]: IOsmosisPoolAsset[]
+}
+
+/**
+ * Map token name to gamm denoms
+ * e.g. gamm/pool/1 -> ATOM-OSMO LP
+ *
+ * @returns a map of token name strings indexed by gamm denom
+ */
+export const useGammTokens = () => {
+  const fetch = useQuery(
+    [queryKey.gammTokens],
+    async () => {
+      try {
+        const { data } = await request.get<IOsmosisPoolResponse>(
+          "/pools/v2/all?low_liquidity=true",
+          { baseURL: OSMOSIS_API_URL }
+        )
+        return data
+      } catch (error) {
+        console.error(error)
+        return
+      }
+    },
+    {
+      // Data will never become stale and always stay in cache
+      cacheTime: Infinity,
+      staleTime: Infinity,
+    }
+  )
+
+  const gammTokens = new Map<string, string>()
+
+  if (fetch.data) {
+    for (const [poolId, poolAsset] of Object.entries(fetch.data)) {
+      gammTokens.set(
+        "gamm/pool/" + poolId,
+        poolAsset.map((asset) => asset.symbol).join("-") + " LP"
+      )
+    }
+  }
+
+  return gammTokens
+}

--- a/src/data/query.ts
+++ b/src/data/query.ts
@@ -35,6 +35,7 @@ export const queryKey = mirror({
   TerraAssets: "",
   TerraAPI: "",
   History: "",
+  gammTokens: "",
 
   /* lcd */
   auth: { accountInfo: "" },

--- a/src/data/token.tsx
+++ b/src/data/token.tsx
@@ -5,9 +5,17 @@ import { AccAddress } from "@terra-money/feather.js"
 import { ASSETS } from "config/constants"
 import { useTokenInfoCW20 } from "./queries/wasm"
 import { useCustomTokensCW20 } from "./settings/CustomTokens"
+import {
+  useGammTokens,
+  GAMM_TOKEN_DECIMALS,
+  OSMO_ICON,
+} from "./external/osmosis"
 import { useCW20Whitelist, useIBCWhitelist } from "./Terra/TerraAssets"
 import { useWhitelist } from "./queries/chains"
-import { useNetworkName } from "./wallet"
+import { useNetworkName, useNetwork } from "./wallet"
+import { getChainIDFromAddress } from "utils/bech32"
+
+const DEFAULT_NATIVE_DECIMALS = 6
 
 export const useTokenItem = (token: Token): TokenItem | undefined => {
   const readNativeDenom = useNativeDenoms()
@@ -73,11 +81,56 @@ export const useNativeDenoms = () => {
   const { whitelist, ibcDenoms, legacyWhitelist } = useWhitelist()
   const { list: cw20 } = useCustomTokensCW20()
   const networkName = useNetworkName()
+  const networks = useNetwork()
+  const gammTokens = useGammTokens()
+
+  let decimals = DEFAULT_NATIVE_DECIMALS
 
   function readNativeDenom(denom: Denom): TokenItem {
-    const fixedDenom = denom.startsWith("ibc/")
-      ? `${readDenom(denom).substring(0, 5)}...`
-      : readDenom(denom)
+    let tokenType = ""
+
+    if (denom.startsWith("ibc/")) {
+      tokenType = "ibc"
+    } else if (denom.startsWith("factory/")) {
+      tokenType = "factory"
+    } else if (denom.startsWith("gamm/")) {
+      tokenType = "gamm"
+      decimals = GAMM_TOKEN_DECIMALS
+    }
+
+    let fixedDenom = ""
+
+    switch (tokenType) {
+      case "ibc":
+        fixedDenom = `${readDenom(denom).substring(0, 5)}...`
+        break
+
+      case "gamm":
+        fixedDenom = gammTokens.get(denom) ?? readDenom(denom)
+        break
+
+      case "factory": {
+        // TODO - lookup whitelist for factory tokens.
+        fixedDenom = "..."
+        break
+      }
+
+      default:
+        fixedDenom = readDenom(denom)
+    }
+
+    let factoryIcon
+    if (tokenType === "factory") {
+      const tokenAddress = denom.split(/[/:]/)[1]
+      const chainID = getChainIDFromAddress(tokenAddress, networks)
+      if (chainID) {
+        factoryIcon = networks[chainID].icon
+      }
+    }
+
+    if (tokenType === "gamm") {
+      factoryIcon = OSMO_ICON
+    }
 
     // native token
     if (whitelist[networkName]?.[denom]) return whitelist[networkName]?.[denom]
@@ -102,10 +155,13 @@ export const useNativeDenoms = () => {
         token: denom,
         symbol: fixedDenom,
         name: fixedDenom,
-        icon: denom.startsWith("ibc/")
-          ? "https://assets.terra.money/icon/svg/IBC.svg"
-          : "https://assets.terra.money/icon/svg/Terra.svg",
-        decimals: 6,
+        icon:
+          tokenType === "ibc"
+            ? "https://assets.terra.money/icon/svg/IBC.svg"
+            : tokenType === "factory" || tokenType === "gamm"
+            ? factoryIcon
+            : "https://assets.terra.money/icon/svg/Terra.svg",
+        decimals,
       }
     )
   }


### PR DESCRIPTION
## Updates
- [x] add data/external/osmosis.ts with osmosis gamm and api information
- [x] add query key to query.ts for react-query access
- [x] update token.ts to account for prefixed native tokens (gamm, ibc, or factory)
- [x] chain.ts already updated to appropriate hide/show low balances of gamm tokens.

## Testing 
- create gamm token on app.osmosis.zone by pooling an asset
- gamm token should appear in wallet with LP pair label

e.g.
<img width="388" alt="image" src="https://github.com/terra-money/station-extension/assets/17463738/b7008b33-3667-45fe-8906-6fbe82dec059">

