### PR TITLE
fix: only link cw20 tokens

### DIFF
--- a/src/pages/custom/TokenItem.tsx
+++ b/src/pages/custom/TokenItem.tsx
@@ -7,6 +7,7 @@ import { truncate } from "@terra-money/terra-utils"
 import { FinderLink } from "components/general"
 import { Token } from "components/token"
 import styles from "./TokenItem.module.scss"
+import { AccAddress } from "@terra-money/feather.js"
 
 const cx = classNames.bind(styles)
 
@@ -29,12 +30,16 @@ const TokenItem = ({ added, onAdd, onRemove, ...props }: Props) => {
   const { token, contract, decimals, ...rest } = props
   const { t } = useTranslation()
 
-  const link = contract && (
-    <FinderLink value={contract}>
-      {truncate(contract)}
-      {!isNil(decimals) && `(${t("decimals")}: ${decimals ?? "6"})`}
-    </FinderLink>
-  )
+  let link
+  if (contract && AccAddress.validate(token)) {
+    link = (
+      <FinderLink value={contract}>
+        {truncate(contract)}
+        {!isNil(decimals) && `(${t("decimals")}: ${decimals ?? "6"})`}
+      </FinderLink>
+    )
+  }
+  // TODO: Link to native token pages.
 
   return (
     <Token

--- a/src/pages/custom/TokenItem.tsx
+++ b/src/pages/custom/TokenItem.tsx
@@ -39,7 +39,6 @@ const TokenItem = ({ added, onAdd, onRemove, ...props }: Props) => {
       </FinderLink>
     )
   }
-  // TODO: Link to native token pages.
 
   return (
     <Token


### PR DESCRIPTION
Only provide link for cw20 tokens, evaluate links for natives.

# Before

https://github.com/terra-money/station-extension/assets/30275692/12120484-2c62-48cc-a74e-0d525bad7959

# After

https://github.com/terra-money/station-extension/assets/30275692/096a9bee-9297-4c32-b427-a7cc63872747