### PR TITLE
hotfix: decouple ibc lunc from luna

### DIFF
--- a/public/firefox.manifest.json
+++ b/public/firefox.manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Station Wallet",
-  "version": "7.2.9",
+  "version": "7.2.9.2",
   "background": {
     "scripts": ["background.js"],
     "persistent": true
@@ -26,6 +26,6 @@
     "128": "icon-128.png",
     "180": "icon-180.png"
   },
-  "permissions": ["storage"],
+  "permissions": ["storage", "alarms"],
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Station Wallet",
-  "version": "7.2.9",
+  "version": "7.2.9.2",
   "background": {
     "service_worker": "background.js",
     "type": "module"
@@ -31,5 +31,5 @@
     "128": "icon-128.png",
     "180": "icon-180.png"
   },
-  "permissions": ["storage"]
+  "permissions": ["storage", "alarms"]
 }

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,5 +1,6 @@
 import extension from "extensionizer"
 import PortStream from "extension-port-stream"
+import browser from "webextension-polyfill"
 
 const connectRemote = (remotePort) => {
   if (remotePort.name !== "TerraStationExtension") {
@@ -200,7 +201,7 @@ const connectRemote = (remotePort) => {
         extension.storage.local.get(["connect", "wallet"], handleGetPubkey)
 
         break
-        
+
       case "suggestChain":
         handleRequest("suggestChain")
         break
@@ -266,3 +267,13 @@ const closePopup = () => {
 
 /* utils */
 const capitalize = (string) => string.charAt(0).toUpperCase() + string.slice(1)
+
+// Invoke alarm periodically to keep service worker persistent
+browser.alarms.create("keep-alive-alarm", {
+  periodInMinutes: 0.25,
+})
+
+browser.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === "keep-alive-alarm") {
+  }
+})

--- a/src/pages/wallet/AssetPage.module.scss
+++ b/src/pages/wallet/AssetPage.module.scss
@@ -22,9 +22,13 @@
   }
 }
 
+.chainlist__container {
+  padding-top: 25px;
+  padding-bottom: 1.6rem;
+}
+
 .chainlist {
   background-color: var(--card-bg-muted);
-  padding-top: 25px;
   padding-inline: 10px;
   grid-area: list;
   display: grid;
@@ -35,14 +39,14 @@
 
 .chainlist__title {
   grid-area: title;
-  margin-bottom: 10px;
+  margin-bottom: 5px;
   padding-left: 10px;
 }
 
 .chainlist__list {
   overflow-y: auto;
   grid-area: list;
-  padding-bottom: 1.6rem;
+  padding-bottom: 1rem;
 }
 
 .actions {

--- a/src/pages/wallet/AssetPage.tsx
+++ b/src/pages/wallet/AssetPage.tsx
@@ -90,9 +90,9 @@ const AssetPage = () => {
           {symbol}
         </p>
       </section>
-      <section className={styles.chainlist}>
+      <section className={styles.chainlist__container}>
         {filteredBalances.length > 0 && (
-          <>
+          <div className={styles.chainlist}>
             <div className={styles.chainlist__title}>
               <h3>{t("Chains")}</h3>
             </div>
@@ -112,10 +112,10 @@ const AssetPage = () => {
                   </div>
                 ))}
             </div>
-          </>
+          </div>
         )}
         {filteredUnsupportedBalances.length > 0 && (
-          <>
+          <div className={styles.chainlist}>
             <div className={styles.chainlist__title}>
               <h3>{t("Unsupported Chains")}</h3>
             </div>
@@ -136,7 +136,7 @@ const AssetPage = () => {
                   </div>
                 ))}
             </div>
-          </>
+          </div>
         )}
       </section>
 

--- a/src/pages/wallet/AssetPage.tsx
+++ b/src/pages/wallet/AssetPage.tsx
@@ -55,9 +55,17 @@ const AssetPage = () => {
     {} as Record<string, { baseDenom: string; chains: string[] }>
   )
 
-  const filteredUnsupportedBalances = balances.filter(
-    (b) => unknownIBCDenoms[b.denom]?.baseDenom === token
-  )
+  const filteredUnsupportedBalances = balances.filter((b) => {
+    // only return unsupported token if the current chain is found in the ibc path
+    if (chain) {
+      return (
+        unknownIBCDenoms[b.denom]?.baseDenom === token &&
+        unknownIBCDenoms[b.denom]?.chains.includes(chain)
+      )
+    }
+
+    return unknownIBCDenoms[b.denom]?.baseDenom === token
+  })
 
   const totalBalance = [
     ...filteredBalances,

--- a/src/pages/wallet/AssetPage.tsx
+++ b/src/pages/wallet/AssetPage.tsx
@@ -60,7 +60,7 @@ const AssetPage = () => {
     if (chain) {
       return (
         unknownIBCDenoms[b.denom]?.baseDenom === token &&
-        unknownIBCDenoms[b.denom]?.chains.includes(chain)
+        unknownIBCDenoms[b.denom]?.chains?.includes(chain)
       )
     }
 


### PR DESCRIPTION
## Before
if the underlying token matches current token, show it.
<img width="380" alt="image" src="https://github.com/terra-money/station-extension/assets/17463738/e5964ac5-5715-437a-a0e7-eab91708a446">

## After
both underlying token AND chain in path must match current token + chain

## Testing
- send lunc to osmosis using https://frontier.osmosis.zone
- go to wallet page and click "luna"
- before change, you will have the option to send lunc back, but it will have luna value assigned
- after change, ibc tokens without matching chains won't appear