### PR TITLE
fix: light theme. bg color for mobile and full page

### DIFF
--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -65,7 +65,7 @@
   );
   --button-default-text: hsl(226 71% 43%);
 
-  --menu-bg: hsl(215 100% 33%);
+  --menu-bg: var(--card-bg);
   --menu-border: hsla(0, 0%, 100%, 0.15);
   --menu-text: hsl(0 0% 91%);
 


### PR DESCRIPTION
- [x] In light mode, use the same header background color for full width as mobile.