### PR TITLE
chore: tidy up spelling/grammar on override warning

### DIFF
--- a/src/app/sections/AdvancedSettings.tsx
+++ b/src/app/sections/AdvancedSettings.tsx
@@ -24,8 +24,9 @@ const AdvancedSettings = () => {
       />
       {replaceKeplr && (
         <FormWarning>
-          To prevent collisions between Keplr and Station, when this fature is
-          enabled uninstall or disable the Keplr extension on your browser.
+          To prevent collisions between Keplr and Station, please uninstall or
+          disable the Keplr extension on your browser when this feature is
+          enabled.
         </FormWarning>
       )}
       <SettingsSelectorToggle


### PR DESCRIPTION
## Before
> To prevent collisions between Keplr and Station, when this fature is enabled uninstall or disable the Keplr extension on your browser.

## After
> To prevent collisions between Keplr and Station, please uninstall or disable the Keplr extension on your browser when this feature is enabled.