### PR TITLE
Added testing to each pr request

### DIFF
--- a/.github/workflows/external-tests.yml
+++ b/.github/workflows/external-tests.yml
@@ -1,0 +1,26 @@
+name: Run Synpress Tests
+
+on:
+  pull_request:
+    branches:
+      - is-srpint-24  # adjust if the main branch has a different name
+
+jobs:
+  run-synpress-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout current repository (terra-money/station-extension)
+      uses: actions/checkout@v2
+
+    - name: Checkout synpress test repository
+      uses: actions/checkout@v2
+      with:
+        repository: DimitrijeDragasevic/synpress
+        path: ./synpress
+
+    - name: Install Dependencies & Run Synpress Tests
+      run: |
+        cd synpress
+        yarn install
+        yarn test:e2e


### PR DESCRIPTION
So I want to try adding this the this sprint branch to make the extension e2e tests run on each pr request. 

Note i want to leave this PR open there are still things to determine.

How should we provide the latest build(current build, now it will grab the latest release binary 7.4.1.1) to the synpress tests: 

1. Can we make a script that removes the line of code from webExtensions.polyfil and remove the array entry from manifest.json after ?
2. Open to any other idea :D