### PR TITLE
hotfix: guard baseAsset / readNativeDenom

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Station Wallet",
-  "version": "7.4.6",
-  "version_name": "7.4.6",
+  "version": "7.4.7",
+  "version_name": "7.4.7",
   "background": {
     "service_worker": "background.js"
   },

--- a/src/extension/modules/TxDetails.tsx
+++ b/src/extension/modules/TxDetails.tsx
@@ -17,10 +17,15 @@ const TxDetails = ({ origin, timestamp, tx }: TxRequest) => {
   const readNativeDenom = useNativeDenoms()
 
   const decimals = useMemo(() => {
-    return (
-      readNativeDenom(network[chainID]?.baseAsset)?.decimals ??
-      DEFAULT_NATIVE_DECIMALS
-    )
+    const baseAsset = network[chainID]?.baseAsset
+
+    if (typeof baseAsset !== "string") {
+      return DEFAULT_NATIVE_DECIMALS
+    }
+
+    const nativeDenom = readNativeDenom(baseAsset)
+
+    return nativeDenom?.decimals ?? DEFAULT_NATIVE_DECIMALS
   }, [network, chainID, readNativeDenom])
 
   const fees = fee?.amount.toData()


### PR DESCRIPTION
- [x] Check if baseAsset is string type before passing into nativeDenom which requires a Denom type (string)