### PR TITLE
Resolve: ST-818

### DIFF
--- a/src/data/external/osmosis.ts
+++ b/src/data/external/osmosis.ts
@@ -43,6 +43,11 @@ export const useGammTokens = () => {
           "/pools/v2/all?low_liquidity=true",
           { baseURL: OSMOSIS_API_URL }
         )
+
+        if (!data || typeof data !== "object") {
+          throw new Error("Invalid API response format")
+        }
+
         return data
       } catch (error) {
         console.error(error)


### PR DESCRIPTION
## Previous Behavior:
If the Osmosis API returns a 200 response type but not the expected data, app throws "Something went wrong" error.

## Testing:
Set up a basic http server that returns a 200 for any route. e.g. [Simple Express Server](https://gist.github.com/mwmerz/7ada28ddf44b432dbcf400d3848d8c6a).
Change the OSMOSIS_API_URL in `osmosis.ts` to the http server.

**Before Change**
"Something went wrong"

**After Change**
Gracefully fails.
